### PR TITLE
design: Todo component UI #13

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,10 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>모두의 투두리스트</title>
+    <script
+      src="https://kit.fontawesome.com/362db53098.js"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { Layout } from 'components/Layout';
-import { TodoContainer } from 'pages/todo';
+import TodoPage from 'pages/Todo';
 
 function App() {
   return (
     <Layout>
-      <TodoContainer />
+      <TodoPage />
     </Layout>
   );
 }

--- a/src/components/Todo/TodoContainer.tsx
+++ b/src/components/Todo/TodoContainer.tsx
@@ -1,0 +1,7 @@
+import TodoPresenter from './TodoPresenter';
+
+const TodoContainer = () => {
+  return <TodoPresenter />;
+};
+
+export default TodoContainer;

--- a/src/components/Todo/TodoPresenter.tsx
+++ b/src/components/Todo/TodoPresenter.tsx
@@ -1,0 +1,127 @@
+import styled from 'styled-components';
+
+interface ITodoPresenter {
+  //
+}
+
+const TodoPresenter: React.FC<ITodoPresenter> = () => {
+  return (
+    <Wrapper>
+      <SubWrapper>
+        <Header>
+          <Form>
+            <Input />
+          </Form>
+          <Btn>
+            <i className="fas fa-plus"></i>
+          </Btn>
+        </Header>
+        <Body>
+          <Row>
+            <ItemWrapper>
+              <Checkbox></Checkbox>
+              <Item>수영</Item>
+            </ItemWrapper>
+            <DeleteBtn>
+              <i className="fas fa-trash-alt"></i>
+            </DeleteBtn>
+          </Row>
+        </Body>
+      </SubWrapper>
+    </Wrapper>
+  );
+};
+
+export default TodoPresenter;
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+const SubWrapper = styled.div`
+  width: 700px;
+  text-align: center;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 200px;
+  padding: 70px;
+  background-color: #81c784;
+`;
+
+const Form = styled.form`
+  width: 100%;
+  height: 100%;
+  margin-right: 40px;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  height: 100%;
+  border: none;
+  outline: none;
+  font-size: 33px;
+  padding-left: 20px;
+`;
+
+const Body = styled.div`
+  height: 800px;
+  border: 5px solid #80c683;
+  padding: 50px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+`;
+
+const ItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Item = styled.div`
+  font-size: 18px;
+`;
+
+const Btn = styled.button`
+  width: 80px;
+  font-size: 33px;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  background-color: #b1f9b3;
+  transition: transform 200ms ease-in;
+  :hover {
+    transform: scale(1.1);
+  }
+`;
+
+const DeleteBtn = styled.button`
+  font-size: 22px;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  transition: transform 200ms ease-in;
+  :hover {
+    transform: scale(1.2);
+  }
+`;
+
+const Checkbox = styled.button`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid gray;
+  background-color: transparent;
+  margin-right: 25px;
+  cursor: pointer;
+`;

--- a/src/components/Todo/index.ts
+++ b/src/components/Todo/index.ts
@@ -1,2 +1,1 @@
 export { default as TodoContainer } from './TodoContainer';
-export { default as TodoPresenter } from './TodoPresenter';

--- a/src/pages/Todo/index.tsx
+++ b/src/pages/Todo/index.tsx
@@ -1,0 +1,7 @@
+import { TodoContainer } from 'components/Todo';
+
+const TodoPage: React.FC = () => {
+  return <TodoContainer />;
+};
+
+export default TodoPage;

--- a/src/pages/todo/TodoContainer.tsx
+++ b/src/pages/todo/TodoContainer.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const TodoContainer = () => {
-  return <div>This is conatianer</div>;
-};
-
-export default TodoContainer;

--- a/src/pages/todo/TodoPresenter.tsx
+++ b/src/pages/todo/TodoPresenter.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const TodoPresenter = () => {
-  return <div></div>;
-};
-
-export default TodoPresenter;


### PR DESCRIPTION
### 작업 내용
- Todo pages에서 components로 분리했습니다. 아무래도 pages도 container-presenter pattern으로 나누는 것 보다 한 컴포넌트에서 공용 컴포넌트들을 조립해서 만드는 식이 더 예쁜 거 같아서 Todo 컴포넌트를 재사용할 일은 없겠지만 공용 컴포넌트로 뺐습니다. 이건 프로젝트 구조에 관련된 거라 일단 변경은 했는데 리뷰해보시고 피드백 주시면 같이 고민해보겠습니다.
- index.html에 font-awesome 스크립트 코드 추가했습니다.
- 기본적인 UI 작업입니다. 차후 추가되는 기능에 맞춰 UI도 변경하겠습니다.

closes #13 